### PR TITLE
add toggle for supervisorctl and associated http server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ supervisord_etc_dir: /etc/supervisor
 supervisord_user: root
 supervisord_socket_path: /var/run/supervisor.sock
 
+# toggle to disable supervisorctl and associated http server used to talk to supervisord
+supervisord_enable_supervisorctl: True
+
 # for specifying a supervisord password
 #supervisord_password: 1ed97bb0-7925-11e6-b641-989096e41e7c
 

--- a/templates/supervisord.conf.j2
+++ b/templates/supervisord.conf.j2
@@ -9,6 +9,7 @@ user = {{supervisord_user}}
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
+{% if supervisord_enable_supervisorctl | bool %}
 [unix_http_server]
 file = {{ supervisord_socket_path }}
 chmod = 700
@@ -18,6 +19,7 @@ password = {SHA}{{ supervisord_password | default(ansible_date_time.epoch | to_u
 
 [supervisorctl]
 serverurl = unix://{{ supervisord_socket_path }}
+{% endif %}
 
 [include]
 files = {{ supervisord_conf_dir}}/*.conf


### PR DESCRIPTION
this PR enables a user to toggle on/off the http server supervisorctl uses to talk to supervisord. In instances where a user may have access to an application's shell this would 

- disable them from using supervisorctl
- remove the [unix_http_server] config from supervisord.conf which contains the plaintext password to connect to the server